### PR TITLE
Display block on PDFs if viewer is present

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -17,3 +17,15 @@ function islandora_downloadable_datastreams_show_for_cmodel(AbstractObject $obje
   $show_cmodels = variable_get('islandora_downloadable_datastreams_selected_cmodels', array('islandora:sp_large_image_cmodel', 'islandora:bookCModel', 'islandora:newspaperIssueCModel'));
   return (array_intersect($object->models, $show_cmodels) == TRUE);
 }
+
+function islandora_downloadable_datastreams_check_viewer($ids) {
+  module_load_include('inc', 'islandora', 'includes/solution_packs');
+  $viewer_map = array(
+    'islandora:sp_pdf' => 'islandora_pdf_viewers',
+    'ir:thesisCModel' => 'islandora_scholar_viewers',
+    'ir:citationCModel' => 'islandora_scholar_viewers',
+  );
+  $cmodel = $ids['cmodel'];
+  $viewers = islandora_get_viewer_id($viewer_map[$cmodel]);
+  return ($viewers);
+}

--- a/islandora_downloadable_datastreams.module
+++ b/islandora_downloadable_datastreams.module
@@ -84,7 +84,7 @@ function islandora_downloadable_datastreams_block_view($delta) {
       elseif ($ids['cmodel'] == 'islandora:sp_pdf') {
         $viewer = islandora_downloadable_datastreams_check_viewer($ids);
         if ($viewer !== "none") {
-          $dsid = "PDF";
+          $dsid = "OBJ";
         }
       }
     // Create the link if a DSID is selected

--- a/islandora_downloadable_datastreams.module
+++ b/islandora_downloadable_datastreams.module
@@ -47,7 +47,6 @@ function islandora_downloadable_datastreams_block_view($delta) {
   $to_render = array();
   // Get object CModel and PID - this may be repeating itself, I'm not sure.
   $object = menu_get_object('islandora_object', 2);
-
   if ($object) {
     $pid = $object->id;
     $ids = array();
@@ -81,6 +80,13 @@ function islandora_downloadable_datastreams_block_view($delta) {
         $dsid = "MP4";
       }
 
+    // For PDF, check if viewer is present
+      elseif ($ids['cmodel'] == 'islandora:sp_pdf') {
+        $viewer = islandora_downloadable_datastreams_check_viewer($ids);
+        if ($viewer !== "none") {
+          $dsid = "PDF";
+        }
+      }
     // Create the link if a DSID is selected
       if ($dsid != "none") {
         global $base_url;


### PR DESCRIPTION
Resolves #9 and #10 by adding a check for whether a viewer is being used for the PDF content model, and, if there is a viewer, displaying the download block.

@mjordan care to test?